### PR TITLE
Support building TrustTunnel on FreeBSD OS

### DIFF
--- a/lib/src/icmp_forwarder.rs
+++ b/lib/src/icmp_forwarder.rs
@@ -397,7 +397,7 @@ impl RawPacketStream {
         };
 
         unsafe {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             let fd = libc::socket(family, libc::SOCK_RAW, protocol);
             #[cfg(target_os = "macos")]
             let fd = libc::socket(family, libc::SOCK_DGRAM, protocol);

--- a/lib/src/net_utils.c
+++ b/lib/src/net_utils.c
@@ -1,10 +1,11 @@
 #include <unistd.h>
 #include <memory.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #ifdef __linux__
 #include <linux/icmp.h>
 #endif
 #include <netinet/icmp6.h>
-#include <sys/socket.h>
 
 
 /**
@@ -49,7 +50,7 @@ int set_icmpv6_filter(int fd) {
 }
 
 int bind_to_interface_by_index(int fd, int family, unsigned idx) {
-#ifndef __linux__
+#ifdef __APPLE__
     int level = IPPROTO_IP;
     int option = IP_BOUND_IF;
     if (family == AF_INET6) {
@@ -59,6 +60,7 @@ int bind_to_interface_by_index(int fd, int family, unsigned idx) {
 
     return setsockopt(fd, level, option, &idx, sizeof(idx));
 #else
+    /* Linux and FreeBSD don't have IP_BOUND_IF */
     (void)fd;
     (void)family;
     (void)idx;


### PR DESCRIPTION
A bunch of code fixes and adjustments to make TrustTunnel build cleanly on FreeBSD.

Note that because of the `boringssl` version currently used by `quiche`, to build TrustTunnel on FreeBSD, one needs to set the `BORING_BSSL_RUST_CPPLIB=c++` variable. This is to make the linker use `libc++` from clang instead of `libstdc+`+. A newer version of `boringssl` has a fix that makes this variable obsolete.