### PR TITLE
Add ca-certificates to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN make endpoint/build-wizard
 FROM debian AS trusttunnel-endpoint
 ARG ENDPOINT_DIR_NAME="TrustTunnel"
 ARG LOG_LEVEL="info"
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=build /home/$ENDPOINT_DIR_NAME/target/release/setup_wizard /bin/
 COPY --from=build /home/$ENDPOINT_DIR_NAME/target/release/trusttunnel_endpoint /bin/
 COPY --chmod=755  /docker-entrypoint.sh /scripts/


### PR DESCRIPTION
## Problem 
 
The runtime Docker image (`FROM debian`) does not include root CA certificates. This causes the setup wizard to fail when issuing a Let's Encrypt certificate via ACME:
 
Failed to create ACME account: no native root CA certificates found (errors: [])

## Fix

Added `ca-certificates` package installation to the final stage of the Dockerfile.

## Steps to reproduce

1. Build the Docker image: `docker compose build`
2. Run the setup wizard: `docker compose run --rm -it --entrypoint /bin/setup_wizard trusttunnel`
3. Choose Let's Encrypt -> HTTP-01 -> production environment
4. ACME account creation fails with the error above

Closes #67 