### PR TITLE
Fix metrics endpoint to include VPN metrics

### DIFF
--- a/lib/src/metrics.rs
+++ b/lib/src/metrics.rs
@@ -104,7 +104,8 @@ impl Metrics {
     fn collect(&self) -> (String, Bytes) {
         let encoder = prometheus::TextEncoder::new();
 
-        let metric_families = prometheus::gather();
+        let mut metric_families = self._registry.gather();
+        metric_families.extend(prometheus::gather());
         let mut buffer = vec![];
         encoder.encode(&metric_families, &mut buffer).unwrap();
 


### PR DESCRIPTION
Closes #70

## Summary

- `Metrics::collect()` uses `prometheus::gather()` which only collects from the default global registry
- VPN metrics (`client_sessions`, `inbound_traffic_bytes`, `outbound_traffic_bytes`, `outbound_tcp_sockets`, `outbound_udp_sockets`) are registered in a separate `Registry` instance created in `Metrics::new()`
- The `/metrics` endpoint only returns process metrics, VPN metrics are missing

## Fix

Collect from both the custom registry (`self._registry.gather()`) and the default registry (`prometheus::gather()`).

## Test plan

- Enable `[metrics]` in `vpn.toml`
- Connect a client
- `curl http://127.0.0.1:1987/metrics` should now include `client_sessions`, traffic and socket metrics