### PR TITLE
docs: add Trusty client to community GUI list

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,8 @@ Available on [App Store][app-store]* and [Play Store][play-store].
 
 #### GUI
 
+[Trusty](https://github.com/Meddelin/trusty) - A cross-platform GUI client built with Flutter (Windows stable, macOS alpha). Features include real-time logs, 1-click SSH server deployment, and split-tunneling domain groups auto-discovery.
+
 [TrustTunnel-GUI-Client](https://github.com/blazuryk/TrustTunnel-GUI-Client) — Windows GUI client, implemented as a Python wrapper for [TrustTunnel Client][trusttunnel-client]
 
 [Surge](https://nssurge.com) — (Commercial) macOS and iOS network toolbox with experimental TrustTunnel support


### PR DESCRIPTION
## Related Issue
<!-- Every non-trivial PR must reference an existing issue. -->
*(Since this is a trivial documentation update, no issue is referenced)*
## Summary
This PR adds **Trusty** to the list of Community GUI clients in the `README.md`. Trusty is a cross-platform GUI wrapper for the TrustTunnel CLI client built with Flutter, featuring real-time logs, simplified TOML configuration, remote 1-click SSH server deployment, and split-tunneling domain groups.
## Changes
- Added Trusty to the `Community -> GUI` clients list in `README.md`.
## Tests
- [ ] New or updated tests cover the changes (N/A - docs only)
- [ ] All existing tests pass (`make test`) (N/A)
- [ ] Benchmarks updated (if performance-relevant) (N/A)
## Checklist
- [x] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-visible change)
- [x] No secrets or credentials committed