### PR TITLE
Add FreeTunnel to community clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ Available on [App Store][app-store]* and [Play Store][play-store].
 
 [FireTunnel](https://github.com/pnsrc/firetunnel) - A cross-platform client written in QT used modified [TrustTunnel Client](https://github.com/pnsrc/TrustTunnelClient/)
 
+[FreeTunnel](https://github.com/dimmmmmmmer/freetunnel) — A free, open-source desktop client for Windows, macOS, and Linux with a native Qt 6 interface, built on the official [TrustTunnel Client][trusttunnel-client]. One-click connect, split tunneling, kill switch, system tray, and signed auto-updates.
+
 ## See Also
 
 - [CONFIGURATION.md](CONFIGURATION.md) - Configuration documentation


### PR DESCRIPTION
Adds [FreeTunnel](https://github.com/dimmmmmmmer/freetunnel) to the Community → GUI clients list.

FreeTunnel is a free, open-source (Apache-2.0) desktop client for Windows, macOS, and Linux with a native Qt 6/QML interface, built on the official unmodified [TrustTunnel Client](https://github.com/TrustTunnel/TrustTunnelClient) core (pinned upstream ref, built from source in CI). One-click connect, split tunneling, kill switch, system tray, `tt://` deep links, and auto-updates verified with SHA-256 manifests and Ed25519 signatures. Prebuilt installers for all three platforms are on the releases page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)