### PR TITLE
Update CONFIGURATION.md

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -522,7 +522,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now trusttunnel
 
 # Reload TLS settings
-sudo systemctl reload trusttunnel
+sudo systemctl restart trusttunnel
 
 # View logs
 sudo journalctl -u trusttunnel -f


### PR DESCRIPTION
# Update CONFIGURATION.md

Change
`sudo systemctl reload trusttunnel`
to
`sudo systemctl restart trusttunnel`
because `reload` unsupported

## Checklist

- [x] Documentation updated
- [x] No secrets or credentials committed
